### PR TITLE
Change README urls and remove deprecated checks

### DIFF
--- a/Casks/pdk@1.rb
+++ b/Casks/pdk@1.rb
@@ -22,7 +22,6 @@ cask 'pdk@1' do
     sha256 '5ee08d46b072b418f3256d0f47d2979255b69e1b5d3e5ba207be390b75eb6482'
   end
 
-  depends_on macos: '>= :el_capitan'
   url "https://downloads.puppet.com/mac/puppet-tools/#{os_ver}/x86_64/pdk-#{version}-1.osx#{os_ver}.dmg"
   pkg "pdk-#{version}-1-installer.pkg"
 

--- a/Casks/puppet-bolt.rb
+++ b/Casks/puppet-bolt.rb
@@ -68,7 +68,6 @@ cask 'puppet-bolt' do
     end
   end
 
-  depends_on macos: '>= :el_capitan'
   url "https://downloads.puppet.com/mac/puppet-tools/#{os_ver}/#{arch}/puppet-bolt-#{version}-1.osx#{os_ver}.dmg"
   pkg "puppet-bolt-#{version}-1-installer.pkg"
 

--- a/Casks/puppet-bolt@2.rb
+++ b/Casks/puppet-bolt@2.rb
@@ -22,7 +22,6 @@ cask 'puppet-bolt@2' do
     sha256 'd8c4cbd2c2d6c4a0d8cb58007de2a7520939c51cabe8845d6d96013062d7e466'
   end
 
-  depends_on macos: '>= :el_capitan'
   url "https://downloads.puppet.com/mac/puppet-tools/#{os_ver}/x86_64/puppet-bolt-#{version}-1.osx#{os_ver}.dmg"
   pkg "puppet-bolt-#{version}-1-installer.pkg"
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A tap for [Puppet](https://puppet.com) macOS packages
 ## How do I install these packages?
 
 ```bash
-brew install --cask puppetlabs/puppet/<package>
+brew install --cask OpenVoxProject/homebrew-openvox/<package>
 ```
 
 ### Bolt
@@ -24,7 +24,7 @@ brew install --cask puppetlabs/puppet/<package>
 To install [Bolt](https://github.com/puppetlabs/bolt) with brew run
 
 ```bash
-brew install --cask puppetlabs/puppet/puppet-bolt
+brew install --cask OpenVoxProject/homebrew-openvox/puppet-bolt
 ```
 
 This will install bolt to `/opt/puppetlabs/bin/bolt`, so to use bolt add `/opt/puppetlabs/bin` to your path
@@ -47,13 +47,13 @@ brew install puppet-bolt@2
 To install the latest version of [PE Client Tools](https://puppet.com/docs/pe/latest/installing_pe_client_tools.html) run
 
 ```bash
-brew install puppetlabs/puppet/pe-client-tools
+brew install OpenVoxProject/homebrew-openvox/pe-client-tools
 ```
 
 To install the client tools for PE 2021, run
 
 ```bash
-brew install puppetlabs/puppet/pe-client-tools
+brew install OpenVoxProject/homebrew-openvox/pe-client-tools
 ```
 
 This will install the standalone commands from pe-client-tools to `/opt/puppetlabs/bin` so you'll need to have `/opt/puppetlabs/bin` in your path. All the commands are also available via a puppet face if you have the puppet-agent installed too.
@@ -63,7 +63,7 @@ This will install the standalone commands from pe-client-tools to `/opt/puppetla
 To install [PDK](https://github.com/puppetlabs/pdk) with brew:
 
 ```bash
-brew install --cask puppetlabs/puppet/pdk
+brew install --cask OpenVoxProject/homebrew-openvox/pdk
 ```
 
 This will install PDK into `/opt/puppetlabs/pdk` and add an entry into `/etc/paths.d` to add PDK to your
@@ -78,7 +78,7 @@ to learn more.
 To install the latest PDK 1.x release, run
 
 ```bash
-brew tap puppetlabs/puppet
+brew tap OpenVoxProject/homebrew-openvox
 brew install pdk@1
 ```
 
@@ -87,7 +87,7 @@ brew install pdk@1
 To install the very latest [Puppet Agent](https://github.com/puppetlabs/puppet-agent) with brew:
 
 ```bash
-brew install puppetlabs/puppet/puppet-agent
+brew install OpenVoxProject/homebrew-openvox/puppet-agent
 ```
 
 Additionally we maintain versioned casks for each collection


### PR DESCRIPTION
Currently this repository gives the error `Warning: Calling 'depends_on macos: :el_capitan' is deprecated! There is no replacement.` when the repo is tapped. In addition, the README also still uses the puppetlabs repo. This fixes both of those.